### PR TITLE
feat(db): add tasks table with RLS policies (#9)

### DIFF
--- a/GITHUB_ISSUES.md
+++ b/GITHUB_ISSUES.md
@@ -1,0 +1,132 @@
+# GitHub Issues Summary
+
+Last fetched: 2025-12-16
+
+## Open Issues
+
+### Epic: Org Members + Invites MVP (#22)
+**Labels:** epic, frontend, backend, db, auth  
+**Status:** Open  
+**Sub-issues:** 3 (0 completed)
+
+**Goal:** Allow org leads to manage members and roles.
+
+**MVP Scope:**
+- Members list
+- Change member role (lead-only)
+- Invite flow (simple)
+
+**Sub-issues:**
+- #25: Backend: Simple invite flow (email or invite link)
+- #24: Auth/Backend: Update member roles (lead-only)
+- #23: Frontend: Members list page
+
+---
+
+### Epic: Announcements MVP (draft + publish) (#18)
+**Labels:** epic, frontend, backend, db, auth  
+**Status:** Open  
+**Sub-issues:** 3 (0 completed)
+
+**Goal:** Ship announcements system for hackathon organizers.
+
+**Sub-issues:**
+- #21: Frontend: Announcements page (list + composer)
+- #20: Backend: Announcements CRUD + publish action
+- #19: DB: Announcements table + RLS policies
+
+---
+
+### Epic: Tasks MVP (assignments + status + due dates) (#8)
+**Labels:** epic, frontend, backend, db  
+**Status:** Open  
+**Sub-issues:** 6 (0 completed)
+
+**Goal:** Ship a usable task system that replaces Notion/Trello for hackathon organizing.
+
+**MVP Scope:**
+- Task CRUD
+- Assign to org member
+- Status: todo/doing/done
+- Due date + priority
+- Filters by team/role + assignee
+
+**Sub-issues:**
+- #12: Frontend: Create/Edit Task form
+- #11: Frontend: Tasks list UI (table or cards)
+- #10: Backend: Task CRUD endpoints/actions
+- #9: DB: Tasks table + RLS policies
+- #13: Frontend: Task assignment UI
+- #14: Frontend: Task filters (team/role/assignee)
+
+---
+
+### Platform: Add subdomain-based organization routing (#7)
+**Labels:** backend, infra  
+**Status:** Open
+
+**Description:** Introduce subdomain-based routing so each organization can access HackPortal via its own subdomain (e.g., deltahacks.hackportal.com).
+
+**Why later:** Intentionally deferred to keep MVP simpler. DB schema already includes org slugs.
+
+**Planned approach:**
+- Wildcard DNS (*.hackportal.com)
+- Middleware to extract org slug from host
+- Replace org selector with implicit org context from subdomain
+- Enforce org access server-side
+
+---
+
+### Epic: Social Login (OAuth providers) (#2)
+**Labels:** epic, auth  
+**Status:** Open  
+**Sub-issues:** 2 (0 completed)
+
+**Sub-issues:**
+- #6: DB: User auth accounts table (OAuth providers)
+- #5: Auth: Add Slack OAuth
+
+---
+
+## Issue Statistics
+
+- **Total Issues:** 25
+- **Open Issues:** 25
+- **Closed Issues:** 0
+
+### By Label
+
+**Epics (3):**
+- #22: Org Members + Invites MVP
+- #18: Announcements MVP
+- #8: Tasks MVP
+- #2: Social Login
+
+**Frontend (8):**
+- #25, #24, #23, #21, #12, #11, #13, #14
+
+**Backend (6):**
+- #25, #24, #20, #10, #7, #5
+
+**Database (3):**
+- #19, #9, #6
+
+**Auth (5):**
+- #25, #24, #19, #6, #5
+
+**Infra (1):**
+- #7
+
+---
+
+## Next Steps
+
+1. **Org Members MVP (#22)** - Foundation for team management
+2. **Tasks MVP (#8)** - Core functionality for hackathon planning
+3. **Announcements MVP (#18)** - Communication system
+4. **Subdomain routing (#7)** - Multi-tenant architecture (future)
+
+---
+
+*For full issue details, visit: https://github.com/faizm10/organizer-portel/issues*
+

--- a/supabase/migrations/0003_tasks_table.sql
+++ b/supabase/migrations/0003_tasks_table.sql
@@ -1,0 +1,100 @@
+-- Tasks table for hackathon organizing workflow
+-- Part of Tasks MVP (#8), sub-issue #9
+
+create table if not exists public.tasks (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations (id) on delete cascade,
+  title text not null,
+  description text,
+  status text not null default 'todo' check (status in ('todo', 'doing', 'done')),
+  priority text check (priority in ('low', 'medium', 'high')),
+  due_date timestamptz,
+  created_by uuid not null references auth.users (id) on delete set null,
+  assigned_to uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+comment on table public.tasks is 'Tasks for hackathon organizing, scoped to organizations.';
+
+-- Index for efficient org-scoped queries
+create index if not exists tasks_org_id_idx on public.tasks (org_id);
+create index if not exists tasks_assigned_to_idx on public.tasks (assigned_to);
+create index if not exists tasks_status_idx on public.tasks (status);
+
+-- Trigger to update updated_at timestamp
+create or replace function public.update_updated_at_column()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+create trigger update_tasks_updated_at
+before update on public.tasks
+for each row
+execute function public.update_updated_at_column();
+
+-- Enable Row Level Security
+alter table public.tasks enable row level security;
+
+-- RLS Policies
+
+-- Org members can read tasks for their organization
+create policy "Org members can read tasks for their org"
+  on public.tasks
+  for select
+  using (
+    exists (
+      select 1
+      from public.org_members m
+      where m.org_id = tasks.org_id
+        and m.user_id = auth.uid()
+    )
+  );
+
+-- Org members can create tasks in their organization
+create policy "Org members can create tasks"
+  on public.tasks
+  for insert
+  with check (
+    exists (
+      select 1
+      from public.org_members m
+      where m.org_id = tasks.org_id
+        and m.user_id = auth.uid()
+    )
+    and created_by = auth.uid()
+  );
+
+-- Org members can update tasks in their organization
+-- (Simplified: all org members can update. Can be tightened later to creator/assignee/leads only)
+create policy "Org members can update tasks"
+  on public.tasks
+  for update
+  using (
+    exists (
+      select 1
+      from public.org_members m
+      where m.org_id = tasks.org_id
+        and m.user_id = auth.uid()
+    )
+  );
+
+-- Org members can delete tasks in their organization
+-- (Simplified: all org members can delete. Can be tightened later to creator/leads only)
+create policy "Org members can delete tasks"
+  on public.tasks
+  for delete
+  using (
+    exists (
+      select 1
+      from public.org_members m
+      where m.org_id = tasks.org_id
+        and m.user_id = auth.uid()
+    )
+  );
+


### PR DESCRIPTION
- Create tasks table with org_id, title, description, status, priority, due_date
- Add indexes for org-scoped queries, assigned_to, and status
- Implement RLS policies: org members can read/create/update/delete tasks in their org
- Add auto-update trigger for updated_at timestamp
- Part of Tasks MVP epic (#8)