### PR TITLE
feat(backend): add task CRUD server actions (#10)

### DIFF
--- a/frontend/app/(app)/announcements/page.tsx
+++ b/frontend/app/(app)/announcements/page.tsx
@@ -1,6 +1,6 @@
 import { NotificationList } from "@/components/animate-ui/components/community/notification-list"
 import { DashboardHeader } from "@/components/dashboard/DashboardHeader"
-import { mockNotifications } from "@/components/dashboard/DashboardPanels"
+import { mockNotifications } from "@/lib/mock-data"
 import { requireUser } from "@/lib/auth"
 import { requireSelectedOrg } from "@/lib/org"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -75,5 +75,6 @@ export default async function AnnouncementsPage() {
     </main>
   )
 }
+
 
 

--- a/frontend/app/(app)/tasks/page.tsx
+++ b/frontend/app/(app)/tasks/page.tsx
@@ -1,6 +1,6 @@
 import { PlayfulTodolist } from "@/components/animate-ui/components/community/playful-todolist"
 import { DashboardHeader } from "@/components/dashboard/DashboardHeader"
-import { mockTasks } from "@/components/dashboard/DashboardPanels"
+import { mockTasks } from "@/lib/mock-data"
 import { requireUser } from "@/lib/auth"
 import { requireSelectedOrg } from "@/lib/org"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -73,5 +73,6 @@ export default async function TasksPage() {
     </main>
   )
 }
+
 
 

--- a/frontend/components/dashboard/DashboardPanels.tsx
+++ b/frontend/components/dashboard/DashboardPanels.tsx
@@ -5,83 +5,7 @@ import { NotificationList } from "@/components/animate-ui/components/community/n
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
-
-export type TaskItem = {
-  id: number
-  label: string
-  done?: boolean
-}
-
-export type NotificationItem = {
-  id: number
-  title: string
-  subtitle: string
-  time: string
-  count?: number
-}
-
-// Hackathon-flavoured mock data that can be reused across pages.
-export const mockTasks: TaskItem[] = [
-  { id: 1, label: "Finalize venue floor plan & power drops", done: true },
-  { id: 2, label: "Publish run-of-show to organizers", done: false },
-  { id: 3, label: "Confirm sponsor workshop times", done: false },
-  { id: 4, label: "Assign mentors to tracks", done: true },
-  { id: 5, label: "Print QR codes for judging portals", done: false },
-  { id: 6, label: "Set up incident response Slack channel", done: true },
-  { id: 7, label: "Schedule volunteer check-in shifts", done: false },
-  { id: 8, label: "Send pre-event email to hackers", done: true },
-]
-
-export const mockNotifications: NotificationItem[] = [
-  {
-    id: 1,
-    title: "New sponsor added",
-    subtitle: "Acme Cloud confirmed Gold sponsorship",
-    time: "3 min ago",
-  },
-  {
-    id: 2,
-    title: "Workshop capacity alert",
-    subtitle: "Intro to LLMs is 90% full",
-    time: "12 min ago",
-  },
-  {
-    id: 3,
-    title: "Logistics",
-    subtitle: "Late-night pizza order submitted to venue",
-    time: "24 min ago",
-  },
-  {
-    id: 4,
-    title: "Judging checklist",
-    subtitle: "Track leads confirmed for final round",
-    time: "40 min ago",
-  },
-  {
-    id: 5,
-    title: "Volunteer shift swap",
-    subtitle: "2 volunteers requested shift changes",
-    time: "1 hr ago",
-  },
-  {
-    id: 6,
-    title: "Mentor availability",
-    subtitle: "Hardware mentors online for next 2 hours",
-    time: "1 hr ago",
-  },
-  {
-    id: 7,
-    title: "Incident resolved",
-    subtitle: "Wi‑Fi saturation in main hall cleared",
-    time: "2 hr ago",
-  },
-  {
-    id: 8,
-    title: "Check-in summary",
-    subtitle: "312 hackers checked in so far",
-    time: "Today",
-  },
-]
+import { mockTasks, mockNotifications } from "@/lib/mock-data"
 
 export function DashboardPanels() {
   return (
@@ -175,5 +99,6 @@ function QuickLink({
     </Card>
   )
 }
+
 
 

--- a/frontend/lib/mock-data.ts
+++ b/frontend/lib/mock-data.ts
@@ -1,0 +1,79 @@
+// Shared mock data for development and placeholder pages
+
+export type TaskItem = {
+  id: number;
+  label: string;
+  done?: boolean;
+};
+
+export type NotificationItem = {
+  id: number;
+  title: string;
+  subtitle: string;
+  time: string;
+  count?: number;
+};
+
+// Hackathon-flavoured mock data that can be reused across pages.
+export const mockTasks: TaskItem[] = [
+  { id: 1, label: "Finalize venue floor plan & power drops", done: true },
+  { id: 2, label: "Publish run-of-show to organizers", done: false },
+  { id: 3, label: "Confirm sponsor workshop times", done: false },
+  { id: 4, label: "Assign mentors to tracks", done: true },
+  { id: 5, label: "Print QR codes for judging portals", done: false },
+  { id: 6, label: "Set up incident response Slack channel", done: true },
+  { id: 7, label: "Schedule volunteer check-in shifts", done: false },
+  { id: 8, label: "Send pre-event email to hackers", done: true },
+];
+
+export const mockNotifications: NotificationItem[] = [
+  {
+    id: 1,
+    title: "New sponsor added",
+    subtitle: "Acme Cloud confirmed Gold sponsorship",
+    time: "3 min ago",
+  },
+  {
+    id: 2,
+    title: "Workshop capacity alert",
+    subtitle: "Intro to LLMs is 90% full",
+    time: "12 min ago",
+  },
+  {
+    id: 3,
+    title: "Logistics",
+    subtitle: "Late-night pizza order submitted to venue",
+    time: "24 min ago",
+  },
+  {
+    id: 4,
+    title: "Judging checklist",
+    subtitle: "Track leads confirmed for final round",
+    time: "40 min ago",
+  },
+  {
+    id: 5,
+    title: "Volunteer shift swap",
+    subtitle: "2 volunteers requested shift changes",
+    time: "1 hr ago",
+  },
+  {
+    id: 6,
+    title: "Mentor availability",
+    subtitle: "Hardware mentors online for next 2 hours",
+    time: "1 hr ago",
+  },
+  {
+    id: 7,
+    title: "Incident resolved",
+    subtitle: "Wi‑Fi saturation in main hall cleared",
+    time: "2 hr ago",
+  },
+  {
+    id: 8,
+    title: "Check-in summary",
+    subtitle: "312 hackers checked in so far",
+    time: "Today",
+  },
+];
+

--- a/frontend/lib/tasks.ts
+++ b/frontend/lib/tasks.ts
@@ -1,0 +1,381 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { requireUser } from "./auth";
+import { getSelectedOrgIdFromCookie, getUserOrganizations } from "./org";
+
+export type TaskStatus = "todo" | "doing" | "done";
+export type TaskPriority = "low" | "medium" | "high";
+
+export type Task = {
+  id: string;
+  org_id: string;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  priority: TaskPriority | null;
+  due_date: string | null;
+  created_by: string;
+  assigned_to: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CreateTaskInput = {
+  title: string;
+  description?: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  due_date?: string;
+  assigned_to?: string;
+};
+
+export type UpdateTaskInput = {
+  title?: string;
+  description?: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  due_date?: string | null;
+  assigned_to?: string | null;
+};
+
+type ActionResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+/**
+ * Verifies that the user is a member of the given organization.
+ */
+async function verifyOrgMembership(
+  userId: string,
+  orgId: string
+): Promise<boolean> {
+  const memberships = await getUserOrganizations(userId);
+  return memberships.some((m) => m.org_id === orgId);
+}
+
+/**
+ * Gets the currently selected organization ID from cookie.
+ * Throws if no org is selected or user is not a member.
+ */
+async function getCurrentOrgId(userId: string): Promise<string> {
+  const orgId = await getSelectedOrgIdFromCookie();
+  if (!orgId) {
+    throw new Error("No organization selected");
+  }
+
+  const isMember = await verifyOrgMembership(userId, orgId);
+  if (!isMember) {
+    throw new Error("Not a member of the selected organization");
+  }
+
+  return orgId;
+}
+
+/**
+ * Lists all tasks for the current organization.
+ */
+export async function listTasks(): Promise<ActionResult<Task[]>> {
+  try {
+    const user = await requireUser();
+    const orgId = await getCurrentOrgId(user.id);
+
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+      .from("tasks")
+      .select("*")
+      .eq("org_id", orgId)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      return { success: false, error: `Failed to fetch tasks: ${error.message}` };
+    }
+
+    return { success: true, data: (data ?? []) as Task[] };
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to list tasks",
+    };
+  }
+}
+
+/**
+ * Gets a single task by ID.
+ */
+export async function getTask(taskId: string): Promise<ActionResult<Task>> {
+  try {
+    const user = await requireUser();
+    const orgId = await getCurrentOrgId(user.id);
+
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+      .from("tasks")
+      .select("*")
+      .eq("id", taskId)
+      .eq("org_id", orgId)
+      .single();
+
+    if (error) {
+      if (error.code === "PGRST116") {
+        return { success: false, error: "Task not found" };
+      }
+      return { success: false, error: `Failed to fetch task: ${error.message}` };
+    }
+
+    return { success: true, data: data as Task };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to get task",
+    };
+  }
+}
+
+/**
+ * Creates a new task in the current organization.
+ */
+export async function createTask(
+  input: CreateTaskInput
+): Promise<ActionResult<Task>> {
+  try {
+    const user = await requireUser();
+    const orgId = await getCurrentOrgId(user.id);
+
+    // Validation
+    if (!input.title || input.title.trim().length === 0) {
+      return { success: false, error: "Title is required" };
+    }
+
+    if (input.title.length > 500) {
+      return { success: false, error: "Title must be 500 characters or less" };
+    }
+
+    if (input.description && input.description.length > 5000) {
+      return {
+        success: false,
+        error: "Description must be 5000 characters or less",
+      };
+    }
+
+    // Validate status if provided
+    if (input.status && !["todo", "doing", "done"].includes(input.status)) {
+      return {
+        success: false,
+        error: "Status must be one of: todo, doing, done",
+      };
+    }
+
+    // Validate priority if provided
+    if (
+      input.priority &&
+      !["low", "medium", "high"].includes(input.priority)
+    ) {
+      return {
+        success: false,
+        error: "Priority must be one of: low, medium, high",
+      };
+    }
+
+    // Validate assigned_to if provided (must be org member)
+    if (input.assigned_to) {
+      const isMember = await verifyOrgMembership(input.assigned_to, orgId);
+      if (!isMember) {
+        return {
+          success: false,
+          error: "Assigned user must be a member of the organization",
+        };
+      }
+    }
+
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+      .from("tasks")
+      .insert({
+        org_id: orgId,
+        title: input.title.trim(),
+        description: input.description?.trim() || null,
+        status: input.status || "todo",
+        priority: input.priority || null,
+        due_date: input.due_date || null,
+        created_by: user.id,
+        assigned_to: input.assigned_to || null,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      return {
+        success: false,
+        error: `Failed to create task: ${error.message}`,
+      };
+    }
+
+    revalidatePath("/tasks");
+    revalidatePath("/dashboard");
+
+    return { success: true, data: data as Task };
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to create task",
+    };
+  }
+}
+
+/**
+ * Updates an existing task.
+ */
+export async function updateTask(
+  taskId: string,
+  input: UpdateTaskInput
+): Promise<ActionResult<Task>> {
+  try {
+    const user = await requireUser();
+    const orgId = await getCurrentOrgId(user.id);
+
+    // First verify the task exists and belongs to the org
+    const taskResult = await getTask(taskId);
+    if (!taskResult.success) {
+      return taskResult;
+    }
+
+    // Validation
+    if (input.title !== undefined) {
+      if (!input.title || input.title.trim().length === 0) {
+        return { success: false, error: "Title cannot be empty" };
+      }
+      if (input.title.length > 500) {
+        return {
+          success: false,
+          error: "Title must be 500 characters or less",
+        };
+      }
+    }
+
+    if (input.description !== undefined && input.description !== null) {
+      if (input.description.length > 5000) {
+        return {
+          success: false,
+          error: "Description must be 5000 characters or less",
+        };
+      }
+    }
+
+    if (input.status && !["todo", "doing", "done"].includes(input.status)) {
+      return {
+        success: false,
+        error: "Status must be one of: todo, doing, done",
+      };
+    }
+
+    if (
+      input.priority !== undefined &&
+      input.priority !== null &&
+      !["low", "medium", "high"].includes(input.priority)
+    ) {
+      return {
+        success: false,
+        error: "Priority must be one of: low, medium, high",
+      };
+    }
+
+    // Validate assigned_to if provided
+    if (input.assigned_to !== undefined && input.assigned_to !== null) {
+      const isMember = await verifyOrgMembership(input.assigned_to, orgId);
+      if (!isMember) {
+        return {
+          success: false,
+          error: "Assigned user must be a member of the organization",
+        };
+      }
+    }
+
+    const supabase = await createClient();
+
+    const updateData: Record<string, unknown> = {};
+    if (input.title !== undefined) updateData.title = input.title.trim();
+    if (input.description !== undefined)
+      updateData.description = input.description?.trim() || null;
+    if (input.status !== undefined) updateData.status = input.status;
+    if (input.priority !== undefined) updateData.priority = input.priority;
+    if (input.due_date !== undefined) updateData.due_date = input.due_date;
+    if (input.assigned_to !== undefined)
+      updateData.assigned_to = input.assigned_to;
+
+    const { data, error } = await supabase
+      .from("tasks")
+      .update(updateData)
+      .eq("id", taskId)
+      .eq("org_id", orgId)
+      .select()
+      .single();
+
+    if (error) {
+      return {
+        success: false,
+        error: `Failed to update task: ${error.message}`,
+      };
+    }
+
+    revalidatePath("/tasks");
+    revalidatePath("/dashboard");
+
+    return { success: true, data: data as Task };
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to update task",
+    };
+  }
+}
+
+/**
+ * Deletes a task.
+ */
+export async function deleteTask(taskId: string): Promise<ActionResult<void>> {
+  try {
+    const user = await requireUser();
+    const orgId = await getCurrentOrgId(user.id);
+
+    // First verify the task exists and belongs to the org
+    const taskResult = await getTask(taskId);
+    if (!taskResult.success) {
+      return taskResult;
+    }
+
+    const supabase = await createClient();
+
+    const { error } = await supabase
+      .from("tasks")
+      .delete()
+      .eq("id", taskId)
+      .eq("org_id", orgId);
+
+    if (error) {
+      return {
+        success: false,
+        error: `Failed to delete task: ${error.message}`,
+      };
+    }
+
+    revalidatePath("/tasks");
+    revalidatePath("/dashboard");
+
+    return { success: true, data: undefined };
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to delete task",
+    };
+  }
+}
+


### PR DESCRIPTION
- Create listTasks, getTask, createTask, updateTask, deleteTask server actions
- All operations enforce org membership and include validation
- Add proper error handling with ActionResult pattern
- Validate title, description, status, priority, and assigned_to fields
- Revalidate cache paths after mutations
- Fix mock data import issue by moving to separate lib/mock-data.ts
- Part of Tasks MVP epic (#8)