### PR TITLE
feat(frontend): add tasks list UI with real data (#11)

### DIFF
--- a/frontend/app/(app)/tasks/page.tsx
+++ b/frontend/app/(app)/tasks/page.tsx
@@ -1,20 +1,70 @@
-import { PlayfulTodolist } from "@/components/animate-ui/components/community/playful-todolist"
-import { DashboardHeader } from "@/components/dashboard/DashboardHeader"
-import { mockTasks } from "@/lib/mock-data"
-import { requireUser } from "@/lib/auth"
-import { requireSelectedOrg } from "@/lib/org"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import { Suspense } from "react";
+import { PlayfulTodolist } from "@/components/animate-ui/components/community/playful-todolist";
+import { DashboardHeader } from "@/components/dashboard/DashboardHeader";
+import { TasksList } from "@/components/tasks/TasksList";
+import { mockTasks } from "@/lib/mock-data";
+import { requireUser } from "@/lib/auth";
+import { requireSelectedOrg } from "@/lib/org";
+import { listTasks } from "@/lib/tasks";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+async function TasksListContent({ orgId }: { orgId: string }) {
+  const result = await listTasks(orgId);
+
+  if (!result.success) {
+    return (
+      <Card>
+        <CardContent className="py-6 text-center">
+          <p className="text-sm text-destructive">
+            Failed to load tasks: {result.error}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return <TasksList tasks={result.data} />;
+}
+
+function TasksListSkeleton() {
+  return (
+    <div className="space-y-3">
+      {[1, 2, 3].map((i) => (
+        <Card key={i}>
+          <CardContent className="p-4">
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-3/4" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
 
 export default async function TasksPage() {
-  const user = await requireUser()
-  const membership = await requireSelectedOrg(user)
-  const org = membership.organization
+  const user = await requireUser();
+  const membership = await requireSelectedOrg(user);
+  const org = membership.organization;
 
   return (
     <main className="mx-auto flex min-h-svh max-w-6xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
-      <DashboardHeader orgName={org.name} userEmail={user.email} role={membership.role} />
+      <DashboardHeader
+        orgName={org.name}
+        userEmail={user.email}
+        role={membership.role}
+      />
 
       <section className="space-y-4">
         <header className="space-y-1">
@@ -26,53 +76,68 @@ export default async function TasksPage() {
         </header>
 
         <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,1.2fr)]">
-          <Card>
-            <CardHeader>
-              <CardTitle>Playful todo list</CardTitle>
-              <CardDescription>
-                A playful view of your core show‑week checklist.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="pt-4">
-              <PlayfulTodolist
-                items={mockTasks.map((t) => ({
-                  id: t.id,
-                  label: t.label,
-                  defaultChecked: t.done ?? false,
-                }))}
-              />
-            </CardContent>
-          </Card>
+          <div className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>All Tasks</CardTitle>
+                <CardDescription>
+                  View and manage all tasks for your organization.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="pt-4">
+                <Suspense fallback={<TasksListSkeleton />}>
+                  <TasksListContent orgId={membership.org_id} />
+                </Suspense>
+              </CardContent>
+            </Card>
+          </div>
 
-          <Card>
-            <CardHeader>
-              <CardTitle>What&apos;s coming</CardTitle>
-              <CardDescription>
-                Planned features for the full Tasks experience.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <ul className="list-disc space-y-1 pl-4 text-sm text-muted-foreground">
-                <li>Timeline-aware tasks tied to your run-of-show.</li>
-                <li>Dependencies like “only if Wi‑Fi incident is closed”.</li>
-                <li>Ownership and on-call rotations for each checklist.</li>
-                <li>Views by team: tech, logistics, sponsorship, outreach.</li>
-                <li>Exports for post-mortems and sponsor reports.</li>
-              </ul>
-              <div className="flex flex-wrap gap-2 pt-2">
-                <Badge variant="secondary">Coming soon</Badge>
-                <Badge variant="outline">Show‑week focused</Badge>
-              </div>
-              <Button size="sm" className="mt-2 rounded-full">
-                Add placeholder task
-              </Button>
-            </CardContent>
-          </Card>
+          <div className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Playful todo list</CardTitle>
+                <CardDescription>
+                  A playful view of your core show‑week checklist.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="pt-4">
+                <PlayfulTodolist
+                  items={mockTasks.map((t) => ({
+                    id: t.id,
+                    label: t.label,
+                    defaultChecked: t.done ?? false,
+                  }))}
+                />
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>What&apos;s coming</CardTitle>
+                <CardDescription>
+                  Planned features for the full Tasks experience.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <ul className="list-disc space-y-1 pl-4 text-sm text-muted-foreground">
+                  <li>Timeline-aware tasks tied to your run-of-show.</li>
+                  <li>Dependencies like "only if Wi‑Fi incident is closed".</li>
+                  <li>Ownership and on-call rotations for each checklist.</li>
+                  <li>Views by team: tech, logistics, sponsorship, outreach.</li>
+                  <li>Exports for post-mortems and sponsor reports.</li>
+                </ul>
+                <div className="flex flex-wrap gap-2 pt-2">
+                  <Badge variant="secondary">Coming soon</Badge>
+                  <Badge variant="outline">Show‑week focused</Badge>
+                </div>
+                <Button size="sm" className="mt-2 rounded-full">
+                  Add placeholder task
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
         </div>
       </section>
     </main>
-  )
+  );
 }
-
-
-

--- a/frontend/components/tasks/TasksList.tsx
+++ b/frontend/components/tasks/TasksList.tsx
@@ -1,0 +1,136 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Calendar, User, AlertCircle } from "lucide-react";
+import type { Task, TaskStatus, TaskPriority } from "@/lib/tasks";
+import { formatDistanceToNow } from "date-fns";
+
+type TasksListProps = {
+  tasks: Task[];
+  onTaskClick?: (task: Task) => void;
+};
+
+const statusColors: Record<TaskStatus, string> = {
+  todo: "bg-muted text-muted-foreground",
+  doing: "bg-blue-500/10 text-blue-700 dark:text-blue-400",
+  done: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+};
+
+const priorityColors: Record<TaskPriority, string> = {
+  low: "bg-muted text-muted-foreground",
+  medium: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+  high: "bg-red-500/10 text-red-700 dark:text-red-400",
+};
+
+export function TasksList({ tasks, onTaskClick }: TasksListProps) {
+  if (tasks.length === 0) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+          <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+            <AlertCircle className="h-6 w-6 text-muted-foreground" />
+          </div>
+          <h3 className="mb-2 text-sm font-semibold">No tasks yet</h3>
+          <p className="mb-4 max-w-sm text-sm text-muted-foreground">
+            Create your first task to start organizing your hackathon workflow.
+          </p>
+          <Button size="sm" className="rounded-full">
+            Create task
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {tasks.map((task) => (
+        <TaskCard key={task.id} task={task} onClick={onTaskClick} />
+      ))}
+    </div>
+  );
+}
+
+function TaskCard({
+  task,
+  onClick,
+}: {
+  task: Task;
+  onClick?: (task: Task) => void;
+}) {
+  const isOverdue =
+    task.due_date &&
+    new Date(task.due_date) < new Date() &&
+    task.status !== "done";
+
+  return (
+    <Card
+      className={`cursor-pointer transition-all hover:border-border hover:shadow-sm ${
+        onClick ? "" : "cursor-default"
+      }`}
+      onClick={() => onClick?.(task)}
+    >
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1 space-y-2">
+            <div className="flex items-start gap-2">
+              <h3 className="flex-1 text-sm font-medium leading-tight">
+                {task.title}
+              </h3>
+              <Badge
+                variant="outline"
+                className={`${statusColors[task.status]} shrink-0`}
+              >
+                {task.status}
+              </Badge>
+            </div>
+
+            {task.description && (
+              <p className="line-clamp-2 text-xs text-muted-foreground">
+                {task.description}
+              </p>
+            )}
+
+            <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+              {task.priority && (
+                <div className="flex items-center gap-1.5">
+                  <span className="h-1.5 w-1.5 rounded-full bg-current" />
+                  <Badge
+                    variant="outline"
+                    className={`h-5 px-1.5 py-0 ${priorityColors[task.priority]}`}
+                  >
+                    {task.priority}
+                  </Badge>
+                </div>
+              )}
+
+              {task.due_date && (
+                <div
+                  className={`flex items-center gap-1.5 ${
+                    isOverdue ? "text-red-600 dark:text-red-400" : ""
+                  }`}
+                >
+                  <Calendar className="h-3 w-3" />
+                  <span>
+                    {isOverdue && "Overdue: "}
+                    {formatDistanceToNow(new Date(task.due_date), {
+                      addSuffix: true,
+                    })}
+                  </span>
+                </div>
+              )}
+
+              {task.assigned_to && (
+                <div className="flex items-center gap-1.5">
+                  <User className="h-3 w-3" />
+                  <span>Assigned</span>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+


### PR DESCRIPTION
- Create TasksList component with card-based layout
- Display task title, status, priority, due date, assignee
- Add empty state and loading skeleton
- Show overdue tasks with red highlighting
- Fix org selection: pass orgId directly to server actions
- Update all task server actions to accept optional orgId parameter
- Fixes 'No organization selected' error for single-org users
- Part of Tasks MVP epic (#8)